### PR TITLE
feat: support N-channel forwarding groups with legacy migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,46 +23,50 @@ If you need support with DisLink please [join my Discord server](https://discord
 ### Global Settings
 Global settings can be found in `global-settings.conf` and define the default values for forwarding messages. This means the `channel-settings` block in `channels.conf` can be deleted to remove repetition if you want all forwarding to be the same format
 
-### Multiple channels
-To forward between multiple channels you just need to add another block in channels.conf. In this example we will omit the `channel-settings` option and just take the global settings from `global-settings.conf`
+### Channel groups
+A channel group is a set of channels that forward messages between each other. Each channel in a group has independent `read` and `write` flags:
+* `read = true` — messages sent in this channel get forwarded to other members
+* `write = true` — messages from other members get forwarded into this channel
 
-For example: 
+Both default to `true`, which gives you two-way mirroring. Drop one to make a channel send-only or receive-only.
+
 ```yaml
 channels = [
   {
-    # Values available: FIRST_TO_SECOND, SECOND_TO_FIRST & BOTH
-    direction = BOTH
-    # channel-id: The ID of the channel you want chat to be forwarded to/from. This can be any type of thread channelThe URL of the webhook you want the bot to use.
-    # webhook-url: The url of the webhook. Given that auto-create-webhooks is enabled in "main.conf" and the bot has MANAGE_WEBHOOKS permissions in the channel, these will be created and saved for you.
-    first-channel {
-      channel-id = "12345"
-      webhook-url = ""
-    }
-    second-channel {
-      channel-id = "54321"
-      webhook-url = ""
-    }
-    # Values available: WEBHOOK & PLAINTEXT
+    # Optional. Used to match channel-settings overrides across config reloads.
+    group-id = "main-bridge"
+    # WEBHOOK or PLAINTEXT
     type = WEBHOOK
+    members = [
+      { channel-id = "12345", webhook-url = "", read = true, write = true },
+      { channel-id = "54321", webhook-url = "", read = true, write = true },
+      # A read-only mirror: receives messages from the others but doesn't push its own back
+      { channel-id = "99999", webhook-url = "", read = false, write = true }
+    ]
   },
   {
-    # Values available: FIRST_TO_SECOND, SECOND_TO_FIRST & BOTH
-    direction = BOTH
-    # channel-id: The ID of the channel you want chat to be forwarded to/from. This can be any type of thread channelThe URL of the webhook you want the bot to use.
-    # webhook-url: The url of the webhook. Given that auto-create-webhooks is enabled in "main.conf" and the bot has MANAGE_WEBHOOKS permissions in the channel, these will be created and saved for you.
-    first-channel {
-      channel-id = "56789"
-      webhook-url = ""
-    }
-    second-channel {
-      channel-id = "98765"
-      webhook-url = ""
-    }
-    # Values available: WEBHOOK & PLAINTEXT
+    group-id = "announcements"
     type = WEBHOOK
+    members = [
+      { channel-id = "56789", webhook-url = "", read = true, write = false },
+      { channel-id = "98765", webhook-url = "", read = false, write = true }
+    ]
   }
 ]
 ```
+
+`webhook-url` is filled in automatically when `auto-create-webhooks` is enabled in `main.conf` and the bot has `MANAGE_WEBHOOKS` in each channel. Custom emotes from other servers need a hand-created webhook URL pasted in — Discord blocks auto-created webhooks from sending them.
+
+### Migrating from the old two-channel config
+The pre-v2.1 `first-channel` / `second-channel` / `direction` form still loads — you don't have to touch your existing config. It maps to the new schema like this:
+
+| Old `direction`     | Equivalent `members` flags                                                 |
+|---------------------|----------------------------------------------------------------------------|
+| `BOTH`              | both channels `read = true, write = true`                                  |
+| `FIRST_TO_SECOND`   | first `read = true, write = false`, second `read = false, write = true`    |
+| `SECOND_TO_FIRST`   | first `read = false, write = true`, second `read = true, write = false`    |
+
+When you're ready to migrate, replace the `first-channel` / `second-channel` / `direction` block with a `members` list. The `channel-settings` block keeps working — to be sure overrides match across upgrades, set a `group-id`.
 ## Placeholders available
 * `%message%`
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ If you need support with DisLink please [join my Discord server](https://discord
 Global settings can be found in `global-settings.conf` and define the default values for forwarding messages. This means the `channel-settings` block in `channels.conf` can be deleted to remove repetition if you want all forwarding to be the same format
 
 ### Channel groups
-A channel group is a set of channels that forward messages between each other. Each channel in a group has independent `read` and `write` flags:
-* `read = true` — messages sent in this channel get forwarded to other members
-* `write = true` — messages from other members get forwarded into this channel
+A channel group is a set of channels that forward messages between each other. Each channel in a group has independent `send` and `receive` flags:
+* `send = true` — messages sent in this channel get forwarded to other members
+* `receive = true` — messages from other members get forwarded into this channel
 
 Both default to `true`, which gives you two-way mirroring. Drop one to make a channel send-only or receive-only.
 
@@ -38,18 +38,18 @@ channels = [
     # WEBHOOK or PLAINTEXT
     type = WEBHOOK
     members = [
-      { channel-id = "12345", webhook-url = "", read = true, write = true },
-      { channel-id = "54321", webhook-url = "", read = true, write = true },
+      { channel-id = "12345", webhook-url = "", send = true, receive = true },
+      { channel-id = "54321", webhook-url = "", send = true, receive = true },
       # A read-only mirror: receives messages from the others but doesn't push its own back
-      { channel-id = "99999", webhook-url = "", read = false, write = true }
+      { channel-id = "99999", webhook-url = "", send = false, receive = true }
     ]
   },
   {
     group-id = "announcements"
     type = WEBHOOK
     members = [
-      { channel-id = "56789", webhook-url = "", read = true, write = false },
-      { channel-id = "98765", webhook-url = "", read = false, write = true }
+      { channel-id = "56789", webhook-url = "", send = true, receive = false },
+      { channel-id = "98765", webhook-url = "", send = false, receive = true }
     ]
   }
 ]
@@ -60,11 +60,11 @@ channels = [
 ### Migrating from the old two-channel config
 The pre-v2.1 `first-channel` / `second-channel` / `direction` form still loads — you don't have to touch your existing config. It maps to the new schema like this:
 
-| Old `direction`     | Equivalent `members` flags                                                 |
-|---------------------|----------------------------------------------------------------------------|
-| `BOTH`              | both channels `read = true, write = true`                                  |
-| `FIRST_TO_SECOND`   | first `read = true, write = false`, second `read = false, write = true`    |
-| `SECOND_TO_FIRST`   | first `read = false, write = true`, second `read = true, write = false`    |
+| Old `direction`   | Equivalent `members` flags                                                  |
+|-------------------|-----------------------------------------------------------------------------|
+| `BOTH`            | both channels `send = true, receive = true`                                 |
+| `FIRST_TO_SECOND` | first `send = true, receive = false`, second `send = false, receive = true` |
+| `SECOND_TO_FIRST` | first `send = false, receive = true`, second `send = true, receive = false` |
 
 When you're ready to migrate, replace the `first-channel` / `second-channel` / `direction` block with a `members` list. The `channel-settings` block keeps working — to be sure overrides match across upgrades, set a `group-id`.
 ## Placeholders available

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -9,3 +9,7 @@ dependencies {
     // Configuration
     implementation("org.spongepowered:configurate-hocon:4.1.2")
 }
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+}

--- a/common/src/main/java/me/anutley/dislink/common/config/ChannelPairConfig.java
+++ b/common/src/main/java/me/anutley/dislink/common/config/ChannelPairConfig.java
@@ -28,21 +28,40 @@ import me.anutley.dislink.common.delivery.sender.MessageSender.Type;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 @SuppressWarnings("FieldMayBeFinal")
 @ConfigSerializable
 public class ChannelPairConfig {
 
     @Comment("""
-            channel-id: The ID of the channel you want chat to be forwarded to/from. This can be any type of thread channel.
-            webhook-url: The url of the webhook. Given that auto-create-webhooks is enabled in "main.conf" and the bot has MANAGE_WEBHOOKS permissions in the channel, these will be created and saved for you.
-            Side note: currently due to a Discord limitation, if you want custom emotes to be forwarded you will need to create the webhook yourself (disabling the auto create webhook feature) and paste the URL here, as Discord doesn't allow webhooks to send custom emotes from other servers.
+            An optional identifier for this channel group, used to look up channel-settings overrides.
+            If left blank, settings are matched by the legacy first-channel + second-channel id pair.
             """)
-    private ChannelConfig firstChannel = new ChannelConfig();
+    private String groupId = "";
 
-    private ChannelConfig secondChannel = new ChannelConfig();
+    @Comment("""
+            The list of channels in this group. Messages from any channel where read = true are forwarded
+            to every other channel in the group where write = true. Both flags default to true.
+            channel-id: the Discord channel id (any guild message channel, threads included).
+            webhook-url: the webhook to send through. If auto-create-webhooks is enabled in main.conf
+            and the bot has MANAGE_WEBHOOKS, this is filled in for you.
+            Side note: custom emotes from other servers require a self-created webhook — Discord won't
+            allow it via auto-created ones.
+            """)
+    private List<ChannelConfig> members = new ArrayList<>(Arrays.asList(new ChannelConfig(), new ChannelConfig()));
 
-    @Comment("Values available: FIRST_TO_SECOND, SECOND_TO_FIRST & BOTH")
-    private Direction direction = Direction.BOTH;
+    @Comment("Legacy field — kept readable for migration. Use `members` for new configs.")
+    private ChannelConfig firstChannel = null;
+
+    @Comment("Legacy field — kept readable for migration. Use `members` for new configs.")
+    private ChannelConfig secondChannel = null;
+
+    @Comment("Legacy field — kept readable for migration. Values: FIRST_TO_SECOND, SECOND_TO_FIRST, BOTH.")
+    private Direction direction = null;
 
     @Comment("These values below can be omitted and the default values specified in \"global-settings.conf\" will be used instead")
     private SettingsConfig channelSettings = new SettingsConfig();
@@ -57,6 +76,12 @@ public class ChannelPairConfig {
 
         String webhookUrl = "";
 
+        @Comment("If true, messages sent in this channel are forwarded to other group members.")
+        boolean read = true;
+
+        @Comment("If true, messages from other group members are forwarded into this channel.")
+        boolean write = true;
+
         public String channelId() {
             return channelId;
         }
@@ -68,12 +93,24 @@ public class ChannelPairConfig {
         public void webhookUrl(String webhookUrl) {
             this.webhookUrl = webhookUrl;
         }
+
+        public boolean read() {
+            return read;
+        }
+
+        public boolean write() {
+            return write;
+        }
     }
 
     public enum Direction {
         FIRST_TO_SECOND,
         SECOND_TO_FIRST,
         BOTH
+    }
+
+    public String groupId() {
+        return groupId;
     }
 
     public ChannelConfig firstChannel() {
@@ -92,5 +129,65 @@ public class ChannelPairConfig {
         return type;
     }
 
+    /**
+     * Returns the channels in this group, transparently handling legacy first/second configs.
+     * If the new {@code members} list is populated with any non-empty channel id, it wins.
+     * Otherwise, falls back to whichever of first/second are populated.
+     */
+    public List<ChannelConfig> effectiveMembers() {
+        if (members != null && hasAnyPopulated(members)) {
+            return members;
+        }
+        boolean firstPopulated = firstChannel != null && !firstChannel.channelId().isEmpty();
+        boolean secondPopulated = secondChannel != null && !secondChannel.channelId().isEmpty();
+        if (firstPopulated || secondPopulated) {
+            List<ChannelConfig> legacy = new ArrayList<>(2);
+            if (firstPopulated) legacy.add(firstChannel);
+            if (secondPopulated) legacy.add(secondChannel);
+            return Collections.unmodifiableList(legacy);
+        }
+        return members != null ? members : Collections.emptyList();
+    }
 
+    /**
+     * Whether messages from this channel should be forwarded to other group members.
+     * For new-schema entries, uses the channel's {@code read} flag.
+     * For legacy first/second entries, derives from the {@code direction} enum.
+     */
+    public boolean canRead(ChannelConfig channel) {
+        if (isLegacyMember(channel)) {
+            if (direction == null) return true;
+            if (channel == firstChannel) {
+                return direction == Direction.BOTH || direction == Direction.FIRST_TO_SECOND;
+            }
+            return direction == Direction.BOTH || direction == Direction.SECOND_TO_FIRST;
+        }
+        return channel.read();
+    }
+
+    /**
+     * Whether messages from other group members should be forwarded into this channel.
+     */
+    public boolean canWrite(ChannelConfig channel) {
+        if (isLegacyMember(channel)) {
+            if (direction == null) return true;
+            if (channel == firstChannel) {
+                return direction == Direction.BOTH || direction == Direction.SECOND_TO_FIRST;
+            }
+            return direction == Direction.BOTH || direction == Direction.FIRST_TO_SECOND;
+        }
+        return channel.write();
+    }
+
+    private boolean isLegacyMember(ChannelConfig channel) {
+        return channel != null && (channel == firstChannel || channel == secondChannel)
+                && !(members != null && hasAnyPopulated(members));
+    }
+
+    private static boolean hasAnyPopulated(List<ChannelConfig> list) {
+        for (ChannelConfig c : list) {
+            if (c != null && c.channelId() != null && !c.channelId().isEmpty()) return true;
+        }
+        return false;
+    }
 }

--- a/common/src/main/java/me/anutley/dislink/common/config/ChannelPairConfig.java
+++ b/common/src/main/java/me/anutley/dislink/common/config/ChannelPairConfig.java
@@ -38,29 +38,31 @@ import java.util.List;
 public class ChannelPairConfig {
 
     @Comment("""
-            An optional identifier for this channel group, used to look up channel-settings overrides.
-            If left blank, settings are matched by the legacy first-channel + second-channel id pair.
+            A unique identifier for this block of channels.
+            This is used to match the settings in this file to the channels that are used to send messages to or from
+            This can be left blank if you are still using the legacy 'first-channel' / 'second-channel' format
+            however changing to the 'members' format is recommended
             """)
-    private String groupId = "";
+    private String groupId = "SET TO UNIQUE VALUE";
 
     @Comment("""
-            The list of channels in this group. Messages from any channel where read = true are forwarded
-            to every other channel in the group where write = true. Both flags default to true.
-            channel-id: the Discord channel id (any guild message channel, threads included).
-            webhook-url: the webhook to send through. If auto-create-webhooks is enabled in main.conf
-            and the bot has MANAGE_WEBHOOKS, this is filled in for you.
-            Side note: custom emotes from other servers require a self-created webhook — Discord won't
-            allow it via auto-created ones.
+            The list of channels in this group:
+            - Messages from any channel where read = true are forwarded to every other channel in the group where write = true. 
+              Both flags default to true.
+            - channel-id: the Discord channel id (any guild message channel, threads included).
+            - webhook-url: the webhook to send through. If auto-create-webhooks is enabled in main.conf
+              and the bot has MANAGE_WEBHOOKS, this is filled in for you.
+            Side note: custom emotes from other servers require a self-created webhook — Discord won't allow it via auto-created ones.
             """)
     private List<ChannelConfig> members = new ArrayList<>(Arrays.asList(new ChannelConfig(), new ChannelConfig()));
 
-    @Comment("Legacy field — kept readable for migration. Use `members` for new configs.")
+    @Comment("Legacy field — kept readable for migration. Use `members` for new configs. Potentially removed in later version")
     private ChannelConfig firstChannel = null;
 
-    @Comment("Legacy field — kept readable for migration. Use `members` for new configs.")
+    @Comment("Legacy field — kept readable for migration. Use `members` for new configs. Potentially removed in later version")
     private ChannelConfig secondChannel = null;
 
-    @Comment("Legacy field — kept readable for migration. Values: FIRST_TO_SECOND, SECOND_TO_FIRST, BOTH.")
+    @Comment("Legacy field — kept readable for migration. Potentially removed in later version. Values: FIRST_TO_SECOND, SECOND_TO_FIRST, BOTH. ")
     private Direction direction = null;
 
     @Comment("These values below can be omitted and the default values specified in \"global-settings.conf\" will be used instead")
@@ -77,10 +79,10 @@ public class ChannelPairConfig {
         String webhookUrl = "";
 
         @Comment("If true, messages sent in this channel are forwarded to other group members.")
-        boolean read = true;
+        boolean send = true;
 
         @Comment("If true, messages from other group members are forwarded into this channel.")
-        boolean write = true;
+        boolean receive = true;
 
         public String channelId() {
             return channelId;
@@ -94,12 +96,12 @@ public class ChannelPairConfig {
             this.webhookUrl = webhookUrl;
         }
 
-        public boolean read() {
-            return read;
+        public boolean send() {
+            return send;
         }
 
-        public boolean write() {
-            return write;
+        public boolean receive() {
+            return receive;
         }
     }
 
@@ -151,10 +153,10 @@ public class ChannelPairConfig {
 
     /**
      * Whether messages from this channel should be forwarded to other group members.
-     * For new-schema entries, uses the channel's {@code read} flag.
+     * For new-schema entries, uses the channel's {@code send} flag.
      * For legacy first/second entries, derives from the {@code direction} enum.
      */
-    public boolean canRead(ChannelConfig channel) {
+    public boolean canSend(ChannelConfig channel) {
         if (isLegacyMember(channel)) {
             if (direction == null) return true;
             if (channel == firstChannel) {
@@ -162,13 +164,13 @@ public class ChannelPairConfig {
             }
             return direction == Direction.BOTH || direction == Direction.SECOND_TO_FIRST;
         }
-        return channel.read();
+        return channel.send();
     }
 
     /**
      * Whether messages from other group members should be forwarded into this channel.
      */
-    public boolean canWrite(ChannelConfig channel) {
+    public boolean canReceive(ChannelConfig channel) {
         if (isLegacyMember(channel)) {
             if (direction == null) return true;
             if (channel == firstChannel) {
@@ -176,7 +178,7 @@ public class ChannelPairConfig {
             }
             return direction == Direction.BOTH || direction == Direction.FIRST_TO_SECOND;
         }
-        return channel.write();
+        return channel.receive();
     }
 
     private boolean isLegacyMember(ChannelConfig channel) {

--- a/common/src/main/java/me/anutley/dislink/common/listener/MessageListener.java
+++ b/common/src/main/java/me/anutley/dislink/common/listener/MessageListener.java
@@ -27,7 +27,6 @@ package me.anutley.dislink.common.listener;
 import me.anutley.dislink.common.DisLink;
 import me.anutley.dislink.common.config.ChannelPairConfig;
 import me.anutley.dislink.common.config.ChannelPairConfig.ChannelConfig;
-import me.anutley.dislink.common.config.ChannelPairConfig.Direction;
 import me.anutley.dislink.common.delivery.sender.MessageSender;
 import me.anutley.dislink.common.delivery.sender.PlainTextSender;
 import me.anutley.dislink.common.delivery.sender.WebhookSender;
@@ -35,8 +34,8 @@ import net.dv8tion.jda.api.entities.channel.unions.GuildMessageChannelUnion;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MessageListener extends ListenerAdapter {
 
@@ -46,88 +45,77 @@ public class MessageListener extends ListenerAdapter {
         this.disLink = disLink;
     }
 
+    private record Route(ChannelPairConfig group, ChannelConfig origin, ChannelConfig destination) {}
+
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
 
         if (!event.isFromGuild()) return;
 
-        getDestinationChannels(event.getGuildChannel()).forEach((channelPair, destinationChannel) -> {
+        for (Route route : routesFor(event.getGuildChannel())) {
 
-            if (invalidAuthor(channelPair, event)) return;
-
-            ChannelConfig originChannel = channelPair.firstChannel().channelId().equals(destinationChannel.channelId()) ?
-                    channelPair.secondChannel() : channelPair.firstChannel();
+            if (invalidAuthor(route.group(), event)) continue;
 
             MessageSender<?, ?> delivery;
 
-            if (channelPair.type().equals(MessageSender.Type.WEBHOOK)) {
+            if (route.group().type().equals(MessageSender.Type.WEBHOOK)) {
                 delivery = new WebhookSender(
                         disLink,
-                        channelPair,
-                        originChannel,
-                        destinationChannel,
+                        route.group(),
+                        route.origin(),
+                        route.destination(),
                         event.getMessage()
                 );
             } else {
                 delivery = new PlainTextSender(
                         disLink,
-                        channelPair,
-                        originChannel,
-                        destinationChannel,
+                        route.group(),
+                        route.origin(),
+                        route.destination(),
                         event.getMessage()
                 );
             }
 
             delivery.execute();
-
-        });
+        }
     }
 
-    private Map<ChannelPairConfig, ChannelConfig> getDestinationChannels(GuildMessageChannelUnion channel) {
+    private List<Route> routesFor(GuildMessageChannelUnion channel) {
         String originChannelId = channel.getId();
+        List<Route> routes = new ArrayList<>();
 
-        Map<ChannelPairConfig, ChannelConfig> channels = new HashMap<>();
+        for (ChannelPairConfig group : disLink.configManager().channelsConfig().channels()) {
 
-        for (ChannelPairConfig pairConfig : disLink.configManager().channelsConfig().channels()) {
+            List<ChannelConfig> members = group.effectiveMembers();
 
-            ChannelConfig firstChannel = pairConfig.firstChannel();
-            ChannelConfig secondChannel = pairConfig.secondChannel();
-
-
-            Direction direction = pairConfig.direction();
-
-            String firstChannelId = firstChannel.channelId();
-            String secondChannelId = secondChannel.channelId();
-
-            if (!originChannelId.equals(firstChannelId) && !originChannelId.equals(secondChannelId)) {
-                continue;
+            ChannelConfig origin = null;
+            for (ChannelConfig member : members) {
+                if (originChannelId.equals(member.channelId())) {
+                    origin = member;
+                    break;
+                }
             }
 
-            if (disLink.jda().getGuildChannelById(firstChannelId) == null) {
-                disLink.debug("A message has been sent in a channel listen in the config, however the destination channel (" + firstChannelId + ") doesn't exist ");
-                continue;
-            }
+            if (origin == null) continue;
+            if (!group.canRead(origin)) continue;
 
-            if (disLink.jda().getGuildChannelById(secondChannelId) == null) {
-                disLink.debug("A message has been sent in a channel listen in the config, however the destination channel (" + secondChannelId + ") doesn't exist ");
-                continue;
-            }
+            for (ChannelConfig destination : members) {
+                if (destination == origin) continue;
+                if (!group.canWrite(destination)) continue;
 
-            if (originChannelId.equals(firstChannelId)) {
+                String destinationId = destination.channelId();
+                if (destinationId == null || destinationId.isEmpty()) continue;
 
-                if (direction.equals(Direction.BOTH) || direction.equals(Direction.FIRST_TO_SECOND))
-                    channels.put(pairConfig, secondChannel);
-            }
+                if (disLink.jda().getGuildChannelById(destinationId) == null) {
+                    disLink.debug("A message has been sent in a channel listed in the config, however the destination channel (" + destinationId + ") doesn't exist ");
+                    continue;
+                }
 
-            if (originChannelId.equals(secondChannelId)) {
-
-                if (direction.equals(Direction.BOTH) || direction.equals(Direction.SECOND_TO_FIRST))
-                    channels.put(pairConfig, firstChannel);
-
+                routes.add(new Route(group, origin, destination));
             }
         }
 
-        return channels;
+        return routes;
     }
 
     private boolean invalidAuthor(ChannelPairConfig channelPair, MessageReceivedEvent event) {

--- a/common/src/main/java/me/anutley/dislink/common/listener/MessageListener.java
+++ b/common/src/main/java/me/anutley/dislink/common/listener/MessageListener.java
@@ -97,11 +97,11 @@ public class MessageListener extends ListenerAdapter {
             }
 
             if (origin == null) continue;
-            if (!group.canRead(origin)) continue;
+            if (!group.canSend(origin)) continue;
 
             for (ChannelConfig destination : members) {
                 if (destination == origin) continue;
-                if (!group.canWrite(destination)) continue;
+                if (!group.canReceive(destination)) continue;
 
                 String destinationId = destination.channelId();
                 if (destinationId == null || destinationId.isEmpty()) continue;

--- a/common/src/main/java/me/anutley/dislink/common/util/SettingsUtil.java
+++ b/common/src/main/java/me/anutley/dislink/common/util/SettingsUtil.java
@@ -26,6 +26,7 @@ package me.anutley.dislink.common.util;
 
 import me.anutley.dislink.common.DisLink;
 import me.anutley.dislink.common.config.ChannelPairConfig;
+import me.anutley.dislink.common.config.ChannelPairConfig.ChannelConfig;
 import org.spongepowered.configurate.ConfigurationNode;
 
 import java.util.Optional;
@@ -44,15 +45,7 @@ public class SettingsUtil {
         ConfigurationNode globalSettingsNode = disLink.configLoader().originalGlobalSettingsNode();
 
         Optional<? extends ConfigurationNode> channelNodeOptional = originalChannelsNode.node("channels").childrenList()
-                .stream().filter(channel -> {
-                    String firstChannel = channel.node("first-channel").node("channel-id").getString();
-                    String secondChannel = channel.node("second-channel").node("channel-id").getString();
-
-                    if (firstChannel == null || secondChannel == null) return false;
-
-                    return channelPair.firstChannel().channelId().equals(firstChannel) && channelPair.secondChannel().channelId().equals(secondChannel);
-
-                })
+                .stream().filter(node -> matchesGroup(node, channelPair))
                 .findFirst();
 
         Object[] settings = setting.split("\\.");
@@ -67,6 +60,29 @@ public class SettingsUtil {
         return globalSettingsNode.node("global-settings").node(settings).virtual() ?
                 disLink.configLoader().globalSettingsNode().node("global-settings").node(settings) :
                 globalSettingsNode.node("global-settings").node(settings);
+    }
+
+    private static boolean matchesGroup(ConfigurationNode node, ChannelPairConfig group) {
+        String groupId = group.groupId();
+        String nodeGroupId = node.node("group-id").getString("");
+
+        if (groupId != null && !groupId.isEmpty() && !nodeGroupId.isEmpty()) {
+            return groupId.equals(nodeGroupId);
+        }
+
+        ChannelConfig first = group.firstChannel();
+        ChannelConfig second = group.secondChannel();
+        if (first != null && second != null) {
+            String nodeFirst = node.node("first-channel").node("channel-id").getString();
+            String nodeSecond = node.node("second-channel").node("channel-id").getString();
+            if (nodeFirst != null && nodeSecond != null
+                    && first.channelId().equals(nodeFirst)
+                    && second.channelId().equals(nodeSecond)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public String getString(ChannelPairConfig channelPair, String setting) {

--- a/common/src/main/java/me/anutley/dislink/common/util/SettingsUtil.java
+++ b/common/src/main/java/me/anutley/dislink/common/util/SettingsUtil.java
@@ -70,6 +70,7 @@ public class SettingsUtil {
             return groupId.equals(nodeGroupId);
         }
 
+        // fallback to matching by channel ids if group id is not set
         ChannelConfig first = group.firstChannel();
         ChannelConfig second = group.secondChannel();
         if (first != null && second != null) {


### PR DESCRIPTION
## Summary

Replaces the two-channel "pair" model with an N-channel "group" model. Each
config entry now declares a list of `members`, where every member has its own
`read` (forward messages out) and `write` (receive messages in) booleans. A
message in any member of a group is forwarded to every other member where
`origin.read && destination.write` is true.

Three servers all-to-all is now one config block instead of three pairs. A
one-way mirror is just `read = true, write = false` on the source and the
inverse on the destinations.

## Backwards compatibility

Existing `channels.conf` files are not rewritten on disk. The legacy
`first-channel` / `second-channel` / `direction` keys still load, and routing
falls through to them when the new `members` list is empty. Both schemas can
coexist; users migrate when they want N-channel support.

| Old `direction`   | Equivalent member flags                                          |
|-------------------|------------------------------------------------------------------|
| `BOTH`            | both `read=true, write=true`                                     |
| `FIRST_TO_SECOND` | first `read=true, write=false`; second `read=false, write=true`  |
| `SECOND_TO_FIRST` | first `read=false, write=true`; second `read=true, write=false`  |

A new optional `group-id` field identifies the group for `channel-settings`
lookups. When omitted, `SettingsUtil` falls back to matching by the legacy
first+second ID pair so existing overrides keep resolving.