### PR TITLE
fix: honor mentions config in plain-text + webhook paths

### DIFF
--- a/common/src/main/java/me/anutley/dislink/common/delivery/message/DisLinkWebhookMessageBuilder.java
+++ b/common/src/main/java/me/anutley/dislink/common/delivery/message/DisLinkWebhookMessageBuilder.java
@@ -28,6 +28,7 @@ import club.minnced.discord.webhook.send.WebhookEmbedBuilder;
 import club.minnced.discord.webhook.send.WebhookMessage;
 import club.minnced.discord.webhook.send.WebhookMessageBuilder;
 import me.anutley.dislink.common.delivery.sender.MessageSender;
+import me.anutley.dislink.common.delivery.sender.WebhookSender;
 
 public class DisLinkWebhookMessageBuilder extends DisLinkMessageBuilder<WebhookMessage> {
 
@@ -40,6 +41,7 @@ public class DisLinkWebhookMessageBuilder extends DisLinkMessageBuilder<WebhookM
         WebhookMessageBuilder webhookMessageBuilder = new WebhookMessageBuilder()
                 .setUsername(sender.getPlaceholderReplacedMessage("messages.webhooks.username-format"))
                 .setAvatarUrl(sender.getPlaceholderReplacedMessage("messages.webhooks.avatar-url"))
+                .setAllowedMentions(((WebhookSender) sender).allowedMentions())
                 .setContent(content());
 
         embeds().forEach(embed -> webhookMessageBuilder.addEmbeds(WebhookEmbedBuilder.fromJDA(embed).build()));

--- a/common/src/main/java/me/anutley/dislink/common/delivery/sender/MessageSender.java
+++ b/common/src/main/java/me/anutley/dislink/common/delivery/sender/MessageSender.java
@@ -243,9 +243,9 @@ public abstract class MessageSender<D, M extends DisLinkMessageBuilder<?>> {
 
     public AllowedMentionsBuilder getAllowedMentions() {
         return new AllowedMentionsBuilder(
-                disLink.settingsUtil().getBoolean(pairConfig, "mentions.everyone"),
+                disLink.settingsUtil().getBoolean(pairConfig, "mentions.user"),
                 disLink.settingsUtil().getBoolean(pairConfig, "mentions.role"),
-                disLink.settingsUtil().getBoolean(pairConfig, "mentions.user")
+                disLink.settingsUtil().getBoolean(pairConfig, "mentions.everyone")
         );
     }
 

--- a/common/src/main/java/me/anutley/dislink/common/delivery/sender/WebhookSender.java
+++ b/common/src/main/java/me/anutley/dislink/common/delivery/sender/WebhookSender.java
@@ -163,9 +163,9 @@ public class WebhookSender extends MessageSender<WebhookClientBuilder, DisLinkWe
 
     public AllowedMentions allowedMentions() {
         return AllowedMentions.none()
-                .withParseEveryone(getAllowedMentions().users())
+                .withParseUsers(getAllowedMentions().users())
                 .withParseRoles(getAllowedMentions().roles())
-                .withParseUsers(getAllowedMentions().everyone());
+                .withParseEveryone(getAllowedMentions().everyone());
     }
 
 }


### PR DESCRIPTION
`DisLinkWebhookMessageBuilder.build()` never called `setAllowedMentions` on its `WebhookMessageBuilder`, and the discord-webhooks library defaults that field to `AllowedMentions.all()`. `WebhookClient.send(WebhookMessage)` reads the message's own field to build the JSON body, the client-level `setAllowedMentions` we set in `WebhookSender.createWebhookClientBuilder` is never consulted on this path. Result: every webhook send told Discord "parse everything," so @everyone always pinged regardless of config.

Fix: forward the sender's allowed mentions onto the message builder so the JSON payload reflects the config.


## Test plan
- [x] Built standalone, ran against a real guild with three channels in one webhook group (`mentions.everyone=false`).
- [x] Posted `@everyone` in the sending channel; targets received the text with no ping.
- [x] Toggle `mentions.everyone=true` and confirm it pings when explicitly enabled.
- [x] Sanity-check plain-text delivery with the swap fix.